### PR TITLE
添加计组实验 Xilinx 工程源码（leafevans_2025_94）

### DIFF
--- a/Grade2/上学期/（必修）计算机组成原理实验_计组实验/leafevans_2025_94/README.md
+++ b/Grade2/上学期/（必修）计算机组成原理实验_计组实验/leafevans_2025_94/README.md
@@ -1,18 +1,18 @@
 # 计算机组成原理实验 — Xilinx 工程源码
 
-> 贡献者：橘星奏 | 修读年份：2025 | 分数：94
+> 贡献者：leafevans | 修读年份：2025 | 分数：94
 
 本资料包含四川大学计算机组成原理课程 **5 个实验**的完整 Xilinx ISE 工程源码（Verilog HDL），使用 **Xilinx ISE Design Suite 14.7** 开发。
 
 ## 实验列表
 
-| 序号 | 实验名称 | 工程文件夹 | 说明 |
-|:---:|---------|-----------|------|
-| 1 | 4 位加法器设计 | `adder_4bits` | 1 位全加器 + 4 位加法器顶层模块 |
-| 2 | 多路选择器（MUX）设计 | `mux` | 2 选 1（32 位 / 5 位）+ 8 选 1（32 位） |
-| 3 | 七段数码管显示驱动 | `Sseg7` | 段码映射、并串转换、16 进制转 8 段码 |
-| 4 | 基于 IP 核的系统设计（IP2SOC） | `OExp03-IP2SOC` | 含 CPU、控制器、GPIO、RAM/ROM IP 核 |
-| 5 | 数据路径设计（DataPath） | `OExp05-DataPath` | 32 位寄存器组、ALU 运算模块、IO 接口 |
+| 序号 | 实验名称                       | 工程文件夹        | 说明                                    |
+| :--: | ------------------------------ | ----------------- | --------------------------------------- |
+|  1   | 4 位加法器设计                 | `adder_4bits`     | 1 位全加器 + 4 位加法器顶层模块         |
+|  2   | 多路选择器（MUX）设计          | `mux`             | 2 选 1（32 位 / 5 位）+ 8 选 1（32 位） |
+|  3   | 七段数码管显示驱动             | `Sseg7`           | 段码映射、并串转换、16 进制转 8 段码    |
+|  4   | 基于 IP 核的系统设计（IP2SOC） | `OExp03-IP2SOC`   | 含 CPU、控制器、GPIO、RAM/ROM IP 核     |
+|  5   | 数据路径设计（DataPath）       | `OExp05-DataPath` | 32 位寄存器组、ALU 运算模块、IO 接口    |
 
 ## 获取源码
 
@@ -21,6 +21,7 @@
 **GitHub 仓库：[leafevans/scu-xilink_projects](https://github.com/leafevans/scu-xilink_projects)**
 
 下载方式：
+
 - 直接下载：点击仓库页面右上角 `Code` → `Download ZIP`
 - Git 克隆：`git clone https://github.com/leafevans/scu-xilink_projects.git`
 

--- a/Grade2/上学期/（必修）计算机组成原理实验_计组实验/橘星奏_2025_94/README.md
+++ b/Grade2/上学期/（必修）计算机组成原理实验_计组实验/橘星奏_2025_94/README.md
@@ -1,0 +1,36 @@
+# 计算机组成原理实验 — Xilinx 工程源码
+
+> 贡献者：橘星奏 | 修读年份：2025 | 分数：94
+
+本资料包含四川大学计算机组成原理课程 **5 个实验**的完整 Xilinx ISE 工程源码（Verilog HDL），使用 **Xilinx ISE Design Suite 14.7** 开发。
+
+## 实验列表
+
+| 序号 | 实验名称 | 工程文件夹 | 说明 |
+|:---:|---------|-----------|------|
+| 1 | 4 位加法器设计 | `adder_4bits` | 1 位全加器 + 4 位加法器顶层模块 |
+| 2 | 多路选择器（MUX）设计 | `mux` | 2 选 1（32 位 / 5 位）+ 8 选 1（32 位） |
+| 3 | 七段数码管显示驱动 | `Sseg7` | 段码映射、并串转换、16 进制转 8 段码 |
+| 4 | 基于 IP 核的系统设计（IP2SOC） | `OExp03-IP2SOC` | 含 CPU、控制器、GPIO、RAM/ROM IP 核 |
+| 5 | 数据路径设计（DataPath） | `OExp05-DataPath` | 32 位寄存器组、ALU 运算模块、IO 接口 |
+
+## 获取源码
+
+完整工程文件请前往原仓库下载：
+
+**GitHub 仓库：[leafevans/scu-xilink_projects](https://github.com/leafevans/scu-xilink_projects)**
+
+下载方式：
+- 直接下载：点击仓库页面右上角 `Code` → `Download ZIP`
+- Git 克隆：`git clone https://github.com/leafevans/scu-xilink_projects.git`
+
+## 使用方法
+
+1. 安装 **Xilinx ISE Design Suite 14.7**
+2. 打开对应实验文件夹中的 `.xise` 工程文件
+3. 综合设计：点击 `Synthesize - XST`
+4. 仿真：点击 `Simulate Behavioral Model`
+
+## 许可证
+
+本项目采用 [CC BY-NC-SA 4.0](https://github.com/leafevans/scu-xilink_projects/blob/main/LICENSE) 许可协议。

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ SCU-CS-Class-Materials/
         ├── （必修）计算机组成原理实验_计组实验
             ├── Kimokcheon_2022_100
             ├── MountMist_2023_95
+            ├── leafevans_2025_94 # 含 Xilinx ISE 工程源码，详见原仓库
         ├── （必修） 财政学
             ├── Karry_2021_92
         ├── （必修）金融学
@@ -346,6 +347,7 @@ SCU-CS-Class-Materials/
 15. [**Tangerin**](https://github.com/Tangerin65)
 16. [**assumeengage**](https://github.com/assumeengagetry)
 17. [**AlanRosston**](https://github.com/AlanRosston)
+18. [**leafevans**](https://github.com/leafevans)
 
 
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ SCU-CS-Class-Materials/
             ├── Kimokcheon_2023_98 #含有 "实验室人员管理系统" 一系列配套文档和源码
             ├── Karry_2022_95 # 含有 "图书管理系统" 源码和汇报 updating 🔥
             ├── MountMist_2024_88 #含有“智慧夜市管理系统”系列文档，但不含源码
+            ├── leafevans_2026_xx # 含课程设计报告
         ├── （必修）研究与开发实践_研开
             ├── Karry_2022_98 # 含有 "物业管理系统" 源码和系统文档 updating 🔥
             ├── MountMist_2024_90 # 小游戏“Ark-knights”源码（仅地址）及报告


### PR DESCRIPTION
## 贡献内容

在 `Grade2/上学期/（必修）计算机组成原理实验_计组实验/` 下新增 `leafevans_2025_94` 文件夹，包含：

- 计算机组成原理 5 个实验的 Xilinx ISE 工程源码说明（README.md）
- 源码托管在原仓库：[leafevans/scu-xilink_projects](https://github.com/leafevans/scu-xilink_projects)

### 实验列表

| 序号 | 实验名称 | 工程文件夹 |
|:---:|---------|-----------|
| 1 | 4 位加法器设计 | adder_4bits |
| 2 | 多路选择器（MUX）设计 | mux |
| 3 | 七段数码管显示驱动 | Sseg7 |
| 4 | 基于 IP 核的系统设计（IP2SOC） | OExp03-IP2SOC |
| 5 | 数据路径设计（DataPath） | OExp05-DataPath |

## 其他改动

- 更新根目录 README.md，添加贡献者信息